### PR TITLE
PHP8.4 support

### DIFF
--- a/src/Workable.php
+++ b/src/Workable.php
@@ -40,7 +40,7 @@ class Workable implements Flushable
     /**
      * Constructor, inject the restful service dependency
      */
-    public function __construct(ClientInterface $httpClient, CacheInterface $cache = null)
+    public function __construct(ClientInterface $httpClient, ?CacheInterface $cache = null)
     {
         $this->httpClient = $httpClient;
         $this->cache = $cache;


### PR DESCRIPTION
Resolves PHP8.4 error

> Deprecated: SilverStripe\Workable\Workable::__construct(): Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead in Workable.php on line 43